### PR TITLE
docs: add metric timeunit example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ Write data by rows:
         greptimedb:write(Client, Metric, Points).
 ```
 
+Write data specifying `timeunit`:
+
+```erlang
+   Metric = #{table => <<"temperatures_nanosec">>,
+              timeunit => nanosecond},
+   Points =
+        [#{fields => #{<<"temperature">> => 1},
+           tags =>
+               #{<<"from">> => <<"mqttx_4b963a8e">>,
+                 <<"host">> => <<"serverA">>,
+                 <<"qos">> => greptimedb_values:int64_value(0),
+                 <<"region">> => <<"hangzhou">>},
+           timestamp => 1705946037724448346}],
+
+    {ok, #{response := {affected_rows, #{value := 1}}}} =
+        greptimedb:write(Client, Metric, Points).
+```
+
 Write in async:
 
 ```erlang


### PR DESCRIPTION
A follow-up README update for https://github.com/GreptimeTeam/greptimedb-client-erl/pull/36